### PR TITLE
Fix `USER_WS` variable

### DIFF
--- a/.github/workflows/workspace_integration_test.yaml
+++ b/.github/workflows/workspace_integration_test.yaml
@@ -32,12 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       STUDIO_LICENSE_KEY: ${{ secrets.studio_license_key || secrets.STUDIO_CI_LICENSE_KEY }}
-      # TODO Remove hardcoded path and replace with github.workspace when the bug is fixed
-      # We need to point USER_WS to the github workspace but the one mounted in the container.
-      # Currently, github variables has a bug of inconsistent
-      # with the variables github.workspace and runner.workspace paths
-      # see https://github.com/actions/runner/issues/2058
-      USER_WS: /__w/${{ github.repository }}/${{ github.repository }}
       ROS_DOMAIN_ID: 49
       ROS_LOCALHOST_ONLY: 1
       RMW_IMPLEMENTATION: rmw_cyclonedds_cpp
@@ -47,6 +41,9 @@ jobs:
       STUDIO_CONFIG_PACKAGE: ${{ inputs.config_package }}
     container: picknikciuser/moveit-studio:${{ needs.setup.outputs.image_tag }}
     steps:
+      - name: Set USER_WS environment variable
+        id: set_user_ws
+        run: echo "USER_WS=/__w/$(basename ${{ github.repository }})/$(basename ${{ github.repository }})" >> $GITHUB_ENV
       - name: License key exists
         run: |
           if [ -z "$STUDIO_LICENSE_KEY" ]; then

--- a/.github/workflows/workspace_integration_test.yaml
+++ b/.github/workflows/workspace_integration_test.yaml
@@ -37,7 +37,7 @@ jobs:
       # Currently, github variables has a bug of inconsistent
       # with the variables github.workspace and runner.workspace paths
       # see https://github.com/actions/runner/issues/2058
-      USER_WS: /github/workspace
+      USER_WS: /__w/${{ env.GITHUB_REPOSITORY }}/${{ env.GITHUB_REPOSITORY }}
       ROS_DOMAIN_ID: 49
       ROS_LOCALHOST_ONLY: 1
       RMW_IMPLEMENTATION: rmw_cyclonedds_cpp

--- a/.github/workflows/workspace_integration_test.yaml
+++ b/.github/workflows/workspace_integration_test.yaml
@@ -37,7 +37,7 @@ jobs:
       # Currently, github variables has a bug of inconsistent
       # with the variables github.workspace and runner.workspace paths
       # see https://github.com/actions/runner/issues/2058
-      USER_WS: /__w/${{ env.GITHUB_REPOSITORY }}/${{ env.GITHUB_REPOSITORY }}
+      USER_WS: /__w/${{ github.repository }}/${{ github.repository }}
       ROS_DOMAIN_ID: 49
       ROS_LOCALHOST_ONLY: 1
       RMW_IMPLEMENTATION: rmw_cyclonedds_cpp


### PR DESCRIPTION
It looks like the `USER_WS` variable was hardcoded to `/github/workspace` a while ago. That path does not exist in the integration test for the UR configs. [Previously](https://github.com/PickNikRobotics/moveit_studio_ur_ws/actions/runs/10183146665/job/28167675971), we were seeing this error
```
raise SystemConfigException(f"User workspace {user_ws} does not exist!")
    moveit_studio_utils_py.system_config.SystemConfigException: User workspace /github/workspace does not exist!
```   
This PR sets the user workspace dynamically.