### PR TITLE
set the USER_WS colcon-defaults.yaml as ~/.colcon/defaults.yaml

### DIFF
--- a/.github/workflows/workspace_integration_test.yaml
+++ b/.github/workflows/workspace_integration_test.yaml
@@ -75,6 +75,9 @@ jobs:
           colcon mixin update
           colcon metadata add default https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml
           colcon metadata update
+          cp $USER_WS/colcon-defaults.yaml ~/.colcon/defaults.yaml
+          echo "Using ~/.colcon/defaults.yaml:"
+          cat ~/.colcon/defaults.yaml
       - name: Install rosdeps
         run: |
           . /opt/ros/humble/setup.sh


### PR DESCRIPTION
CI is not setting the `~/.colcon/defaults.yaml` file, which can create inconsistencies between the MoveIt Pro build (e.g. `moveit_studio_behavior_interface`) and Behaviors in the workspace that use MP interfaces.
See https://picknik.slack.com/archives/C01HWFR3KAB/p1715191986309259
Found when working on https://github.com/PickNikRobotics/moveit_studio_ur_ws/pull/331.