### PR TITLE
Skip Tests for Packages in src/external_dependencies if Folder Exists

### DIFF
--- a/.github/workflows/workspace_integration_test.yaml
+++ b/.github/workflows/workspace_integration_test.yaml
@@ -110,6 +110,9 @@ jobs:
           . /opt/overlay_ws/install/setup.sh
           colcon build ${{ inputs.colcon_build_args }} ${{ steps.check_config_package.outputs.config_package_build_arg }}
       - name: Run colcon test
+        defaults:
+          run:
+            shell: bash
         run: |
           . /opt/ros/humble/setup.sh
           . /opt/underlay_ws/install/setup.sh
@@ -121,7 +124,12 @@ jobs:
           export DISPLAY=:99
           Xvfb :99 -screen 0 1024x768x24 &
           echo "Running colcon test"
-          colcon test --retest-until-pass 1 ${{ inputs.colcon_test_args }} ${{ steps.check_config_package.outputs.config_package_test_arg }}
+          external_packages="$(colcon list --base-paths src/external_dependencies --names-only || true)"
+          if [ -n "$external_packages" ]; then
+              colcon test --packages-skip $external_packages --retest-until-pass 1 ${{ inputs.colcon_test_args }} ${{ steps.check_config_package.outputs.config_package_test_arg }}
+          else
+              colcon test --retest-until-pass 1 ${{ inputs.colcon_test_args }} ${{ steps.check_config_package.outputs.config_package_test_arg }}
+          fi
       - if: always()
         run: |
           colcon test-result --verbose


### PR DESCRIPTION
We shouldn't fail CI jobs because external dependencies fail CI. This checks to see if the workspace contains a `src/external_dependencies` folder and, if so, skips tests for packages contained in that folder.