### PR TITLE
Add mujoco_ci_timestep input to workspace integration test workflow

### DIFF
--- a/.github/workflows/workspace_integration_test.yaml
+++ b/.github/workflows/workspace_integration_test.yaml
@@ -101,10 +101,11 @@ jobs:
               if not mujoco_root.search(text):
                   continue
               # Strip any existing `timestep="..."` attribute on <option> elements first
+              # allowing XML-valid whitespace around `=` and either quote style,
               # so a later <option timestep="..."> cannot override the injected CI
               # timestep when MuJoCo merges <option> attributes across elements (last wins).
               stripped = re.sub(
-                  r'(<option\b[^>]*?)\s+timestep="[^"]*"',
+                  r"""(<option\b[^>]*?)\s+timestep\s*=\s*(?:"[^"]*"|'[^']*')""",
                   r'\1',
                   text,
               )

--- a/.github/workflows/workspace_integration_test.yaml
+++ b/.github/workflows/workspace_integration_test.yaml
@@ -101,7 +101,8 @@ jobs:
               if not mujoco_root.search(text):
                   continue
               # Strip any existing `timestep="..."` attribute on <option> elements first
-              # so we don't end up with two on the same element.
+              # so a later <option timestep="..."> cannot override the injected CI
+              # timestep when MuJoCo merges <option> attributes across elements (last wins).
               stripped = re.sub(
                   r'(<option\b[^>]*?)\s+timestep="[^"]*"',
                   r'\1',

--- a/.github/workflows/workspace_integration_test.yaml
+++ b/.github/workflows/workspace_integration_test.yaml
@@ -18,6 +18,14 @@ on:
       runner:
         type: string
         default: "studio_16_core_runner"
+      mujoco_ci_timestep:
+        description: >
+          If non-empty, set MuJoCo `<option timestep>` to this value (seconds) on every
+          top-level `<mujoco>` scene file under `src/` before build. Used to keep the
+          simulator at-or-under realtime on slower CI runners; leave empty for normal
+          runs. Suggested: "0.004" (250 Hz).
+        type: string
+        default: ""
 
     secrets:
       moveit_license_key:
@@ -63,6 +71,62 @@ jobs:
         with:
           submodules: recursive
           lfs: true
+
+      # MuJoCo 3.6.0's heavier constraint solver makes some scenes run slower than
+      # realtime on CI runners, which surfaces as flaky gripper/camera timeouts.
+      # When `mujoco_ci_timestep` is set, inject an `<option timestep="..." />` into
+      # every top-level MuJoCo scene under `src/` so the sim stays at-or-under realtime.
+      # MuJoCo merges multiple <option> elements, so this just adds (or overrides) the
+      # timestep attribute without disturbing other settings (integrator, impratio, ...).
+      - name: Override MuJoCo timestep for CI
+        if: inputs.mujoco_ci_timestep != ''
+        env:
+          MUJOCO_CI_TIMESTEP: ${{ inputs.mujoco_ci_timestep }}
+        run: |
+          python3 - <<'PY'
+          import os, re, pathlib
+          ts = os.environ['MUJOCO_CI_TIMESTEP']
+          # Reject anything that isn't a positive float to keep the sed-like inject safe.
+          if not re.fullmatch(r'\d+(\.\d+)?(e-?\d+)?', ts) or float(ts) <= 0:
+              raise SystemExit(f"mujoco_ci_timestep must be a positive number, got {ts!r}")
+          # Match `<mujoco>` or `<mujoco ...>` but not `<mujocoinclude>` (mujoco followed
+          # by space, '>', or '/').
+          mujoco_root = re.compile(r'(<mujoco[\s>/])')
+          patched = []
+          for path in pathlib.Path('src').rglob('*.xml'):
+              try:
+                  text = path.read_text(encoding='utf-8')
+              except (UnicodeDecodeError, OSError):
+                  continue
+              if not mujoco_root.search(text):
+                  continue
+              # Strip any existing `timestep="..."` attribute on <option> elements first
+              # so we don't end up with two on the same element.
+              stripped = re.sub(
+                  r'(<option\b[^>]*?)\s+timestep="[^"]*"',
+                  r'\1',
+                  text,
+              )
+              # Inject a new <option timestep="..."/> right after the opening <mujoco ...>
+              # tag. MuJoCo merges <option> attributes across elements (last wins).
+              opening = re.compile(r'(<mujoco\b[^>]*>)')
+              new_text, n = opening.subn(
+                  r'\1\n  <option timestep="' + ts + '" />  <!-- CI override (moveit_pro_ci) -->',
+                  stripped,
+                  count=1,
+              )
+              if n:
+                  path.write_text(new_text, encoding='utf-8')
+                  patched.append(str(path))
+          if not patched:
+              raise SystemExit(
+                  f"mujoco_ci_timestep={ts} was set but no <mujoco> scene files were "
+                  "found under src/. Refusing to proceed silently."
+              )
+          print(f"Patched {len(patched)} MuJoCo scene file(s) with timestep={ts}:")
+          for p in patched:
+              print(f"  {p}")
+          PY
 
       # The 'lo' interfaces will not have multicast, and will fail trying to claim a participant index
       # with the default cyclone dds config. We set one for the unit tests to be able to execute.


### PR DESCRIPTION
## Summary

Adds an opt-in `mujoco_ci_timestep` input to the reusable `workspace_integration_test.yaml` workflow. When set, a step after checkout patches every top-level `<mujoco>` scene file under `src/` to inject `<option timestep="..." />`, overriding the simulator timestep for CI runs only.

## Why

The MuJoCo `3.2.7 → 3.6.0` upgrade in `moveit_pro` (`6eedef88a5`, Apr 14) made the constraint solver heavier per step. On CI runners that's slower than realtime — surfacing as `Mujoco model timestep not running in realtime. Increase the model timestep.` warnings and timing-related flakes in `moveit_pro_example_ws#main` integration tests:

| Period | Pass | Fail |
|---|---|---|
| Apr 8–14 (pre-upgrade) | 24 | 0 |
| Apr 17 | 1 | 7 |
| Apr 20–30 | ~3 | ~37 |

Failure modes were `MoveGripperAction` 15s timeouts and `GetImage` 5s wrist-camera timeouts — both downstream of MuJoCo not keeping up. Several mitigations have already been applied (constraint-arena memory bump, MPC retunes, push-button tolerance, publisher timeout fixes); none addressed the underlying realtime gap.

This PR provides a clean knob for consumers to coarsen the sim timestep on CI without affecting dev runs (where the warning is diagnostic and the simulator generally runs faster than realtime). Default is empty / no-op, so existing consumers see no change.

## Implementation notes

- Detection of "real" scene files uses `<mujoco\b[\s>/]`, which matches `<mujoco>` and `<mujoco model="...">` but **not** `<mujocoinclude>` (used by `*_globals.xml` partials). Verified locally against `lab_sim`'s scene files and globals.
- The patch first strips any existing `timestep="..."` attribute on `<option>` elements, then injects a fresh `<option timestep="..." />` immediately after the opening `<mujoco ...>` tag. MuJoCo merges multiple `<option>` elements with last-wins, so this overrides without disturbing `integrator`, `impratio`, `noslip_iterations`, etc.
- Input value is validated as a positive number before substitution.
- A no-op patch (input set, no scene files matched) fails the job loudly rather than silently — protects against rename/refactor drift.

## Test plan

- [ ] Companion PR on `moveit_pro_example_ws` pins to this branch's SHA and passes `mujoco_ci_timestep: "0.004"`. Verify CI flakes drop materially across multiple runs.
- [ ] Verify a workspace that does **not** set `mujoco_ci_timestep` runs identically to before (no patch step executed).
- [ ] After merge, cut a new tag (v0.0.9) so consumers can pin a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)