### PR TITLE
Add use_ccache input to workspace_integration_test workflow

### DIFF
--- a/.github/workflows/workspace_integration_test.yaml
+++ b/.github/workflows/workspace_integration_test.yaml
@@ -26,6 +26,13 @@ on:
           runs. Suggested: "0.004" (250 Hz).
         type: string
         default: ""
+      use_ccache:
+        description: >
+          If true, use ccache to speed up the colcon build. The ccache directory is
+          restored from and saved to the GitHub Actions cache, and
+          `CMAKE_{C,CXX}_COMPILER_LAUNCHER` is set to `ccache` for the build step.
+        type: boolean
+        default: false
 
     secrets:
       moveit_license_key:
@@ -173,11 +180,60 @@ jobs:
           rosdep update
           rosdep install --from-paths src --ignore-src -r -y
 
+      - name: Restore ccache
+        if: inputs.use_ccache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: ccache-${{ inputs.image_tag }}-${{ matrix.ros_distro }}-${{ inputs.config_package }}-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ inputs.image_tag }}-${{ matrix.ros_distro }}-${{ inputs.config_package }}-
+            ccache-${{ inputs.image_tag }}-${{ matrix.ros_distro }}-
+
+      - name: Configure ccache
+        if: inputs.use_ccache
+        env:
+          CCACHE_DIR: ${{ github.workspace }}/.ccache
+        run: |
+          if ! command -v ccache >/dev/null 2>&1; then
+            apt-get update
+            apt-get install -y --no-install-recommends ccache
+          fi
+          mkdir -p "$CCACHE_DIR"
+          ccache --set-config=max_size=5G
+          ccache --set-config=compression=true
+          ccache --zero-stats
+          ccache --show-config
+
       - name: Run colcon build
+        env:
+          CCACHE_DIR: ${{ github.workspace }}/.ccache
         run: |
           . /opt/ros/humble/setup.sh
           . /opt/overlay_ws/install/setup.sh
-          colcon build ${{ inputs.colcon_build_args }} ${{ steps.check_config_package.outputs.config_package_build_arg }}
+          # When ccache is enabled, pass the compiler-launcher defines via
+          # `colcon build --cmake-args` rather than via env vars: it is explicit,
+          # works regardless of build-tree state, and avoids setting empty
+          # `CMAKE_{C,CXX}_COMPILER_LAUNCHER` env values that could override a
+          # caller-provided launcher when `use_ccache` is false.
+          ccache_cmake_args=""
+          if [ "${{ inputs.use_ccache }}" = "true" ]; then
+            ccache_cmake_args="--cmake-args -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+          fi
+          colcon build ${{ inputs.colcon_build_args }} ${{ steps.check_config_package.outputs.config_package_build_arg }} $ccache_cmake_args
+
+      - name: Show ccache stats
+        if: inputs.use_ccache && always()
+        env:
+          CCACHE_DIR: ${{ github.workspace }}/.ccache
+        run: ccache --show-stats --verbose
+
+      - name: Save ccache
+        if: inputs.use_ccache && always()
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: ccache-${{ inputs.image_tag }}-${{ matrix.ros_distro }}-${{ inputs.config_package }}-${{ github.sha }}
 
       - name: Run colcon test
         run: |


### PR DESCRIPTION
## Problem

`workspace_integration_test` rebuilds the workspace from scratch on every invocation, even when the same workflow is run repeatedly against a slowly-changing source tree (e.g. iterating on a single config package, or rerunning after a flaky test). Recompiling ROS packages is the dominant cost of these jobs, and most compile units are unchanged between runs.

## Alternatives considered

- **Cache `build/` and `install/` directories directly.** Simpler to wire up, but `colcon` is sensitive to stale CMake configure state and reused install trees can mask real build breakage. Compiler-output caching via ccache is the well-trodden, low-risk path for ROS CI.
- **Use the `ccache` colcon mixin.** Requires the calling repo's `colcon-defaults.yaml` to include the mixin and would silently no-op in repos that don't, making the input's behavior caller-dependent. Setting `CMAKE_{C,CXX}_COMPILER_LAUNCHER` directly is self-contained and works regardless of the caller's colcon config.
- **Enable ccache unconditionally.** Cache hits cost a small amount of compile-time overhead and a few minutes of cache transfer per job; not every caller wants to pay that on first-run / cold-cache scenarios. A default-false opt-in keeps existing callers byte-identical.

## Chosen approach

Add a `use_ccache` boolean input (default `false`). When `true`:

- Restore the ccache directory from the GitHub Actions cache, keyed by `image_tag`, `ros_distro`, and `config_package`. Restore-keys fall back to prior runs on the same image/distro so a new config_package still gets partial reuse. The trailing dash on each restore-key pins the prefix to the `-<sha>` boundary so it can't match a sibling key (e.g. a different `config_package` whose name starts with the same prefix).
- Install ccache in the container if it isn't already present, cap the cache at 5 GiB with compression on, and zero stats so the post-build report reflects only this run.
- Export `CMAKE_{C,CXX}_COMPILER_LAUNCHER=ccache` only on the `colcon build` step (no global env that could leak into test runs).
- After the build, print `ccache --show-stats --verbose` and save the cache. Both use `if: always()` so a partially-warmed cache survives test failures and the stats are visible when debugging.

Tradeoff: GitHub-hosted cache has per-repo size limits (10 GiB) and a 7-day LRU eviction policy. With 5 GiB per `(image_tag, ros_distro, config_package)` shard this is fine in practice, but heavy use across many config packages could push older shards out — acceptable for an opt-in speedup.