### PR TITLE
feat: add find_release_branch for other repos to use

### DIFF
--- a/.github/actions/find_release_branch/action.yaml
+++ b/.github/actions/find_release_branch/action.yaml
@@ -1,0 +1,42 @@
+name: 'Find Release Branch'
+description: 'Find the highest v<major>.<minor> branch in the repository.'
+outputs:
+  branch:
+    description: 'The release branch name (e.g. v9.5).'
+    value: ${{ steps.find_branch.outputs.branch }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Find highest release branch
+      id: find_branch
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      with:
+        script: |
+          const owner = context.repo.owner;
+          const repo = context.repo.repo;
+
+          const branchPattern = /^v(\d+)\.(\d+)$/;
+          const branches = await github.paginate(github.rest.repos.listBranches, {
+            owner,
+            repo,
+            per_page: 100,
+          });
+
+          const versionBranches = branches
+            .map(b => b.name)
+            .filter(name => branchPattern.test(name))
+            .sort((a, b) => {
+              const [, aMajor, aMinor] = a.match(branchPattern).map(Number);
+              const [, bMajor, bMinor] = b.match(branchPattern).map(Number);
+              return bMajor - aMajor || bMinor - aMinor;
+            });
+
+          if (versionBranches.length === 0) {
+            core.setFailed('No branch matching v<major>.<minor> found.');
+            return;
+          }
+
+          const branch = versionBranches[0];
+          core.info(`Found release branch: ${branch}`);
+          core.setOutput('branch', branch);

--- a/README.md
+++ b/README.md
@@ -49,3 +49,16 @@ The reusable workflow runs each job once per supported ROS distro via a matrix. 
 - **Jazzy** (`jazzy`)
 
 For each distro, the workflow pulls `picknikciuser/moveit-studio:<image_tag>-<ros_distro>`. MoveIt Pro began supporting ROS Jazzy in 9.2.0. Jobs for each distro run in parallel and are reported as separate matrix entries in the GitHub Actions UI.
+
+## Reusable Actions
+
+### `find_release_branch`
+Composite action that lists the calling repository's branches and outputs the highest `v<major>.<minor>` branch name (e.g. `v9.5`). Used by the `batch-merge-release-branch` workflows across MoveIt Pro repos to pick the active release branch to merge into `main`.
+```yaml
+- name: Get current release branch
+  id: get_current_release_branch
+  uses: PickNikRobotics/moveit_pro_ci/.github/actions/find_release_branch@<commit-sha>
+- name: Use it
+  run: echo "Release branch is ${{ steps.get_current_release_branch.outputs.branch }}"
+```
+Pin by commit SHA for reproducibility.


### PR DESCRIPTION
part 1 of 2 part migration from everyone getting this from `moveit_pro_example_ws`
