### PR TITLE
feat: Add mujoco_ci_camera_resolution input to cap render cost on CI

### DIFF
--- a/.github/workflows/workspace_integration_test.yaml
+++ b/.github/workflows/workspace_integration_test.yaml
@@ -26,6 +26,17 @@ on:
           runs. Suggested: "0.004" (250 Hz).
         type: string
         default: ""
+      mujoco_ci_camera_resolution:
+        description: >
+          If non-empty, force every MuJoCo `<camera>` element under `src/` that already
+          has a `resolution="..."` attribute to this "WIDTH HEIGHT" value before build.
+          Used to cap per-frame render cost on slower CI runners; leave empty for normal
+          runs. The scene's `<global offwidth offheight>` is left untouched (it only needs
+          to be >= the largest camera, so shrinking cameras alone is sufficient). Cameras
+          without an existing `resolution=` attribute are left alone (typically URDF
+          cameras with non-MuJoCo syntax). Suggested: "640 480".
+        type: string
+        default: ""
       use_ccache:
         description: >
           If true, use ccache to speed up the colcon build. The ccache directory is
@@ -137,6 +148,53 @@ jobs:
           print(f"Patched {len(patched)} MuJoCo scene file(s) with timestep={ts}:")
           for p in patched:
               print(f"  {p}")
+          PY
+
+      # Bigger camera `resolution="W H"` values (e.g. 1280x720) multiply per-frame
+      # render cost and can push perception-heavy integration tests past their
+      # timeout on CI runners. When `mujoco_ci_camera_resolution` is set, rewrite
+      # every existing `<camera ... resolution="...">` attribute under `src/` to
+      # this value. Cameras without an existing `resolution=` attribute are left
+      # alone (typically URDF cameras with non-MuJoCo `<sensor>` syntax).
+      - name: Override MuJoCo camera resolution for CI
+        if: inputs.mujoco_ci_camera_resolution != ''
+        env:
+          MUJOCO_CI_CAMERA_RESOLUTION: ${{ inputs.mujoco_ci_camera_resolution }}
+        run: |
+          python3 - <<'PY'
+          import os, re, pathlib
+          res = os.environ['MUJOCO_CI_CAMERA_RESOLUTION'].strip()
+          m = re.fullmatch(r'(\d+)\s+(\d+)', res)
+          if not m or int(m.group(1)) <= 0 or int(m.group(2)) <= 0:
+              raise SystemExit(
+                  f"mujoco_ci_camera_resolution must be 'WIDTH HEIGHT' positive integers, got {res!r}"
+              )
+          res_norm = f"{m.group(1)} {m.group(2)}"
+          # Rewrite `resolution="..."` (or single-quoted) inside any <camera ...>
+          # start tag. `[^>]` excludes `>` (and includes newlines), so multi-line
+          # <camera> tags are handled without re.DOTALL.
+          attr = re.compile(
+              r"""(<camera\b[^>]*?\bresolution\s*=\s*)("[^"]*"|'[^']*')""",
+          )
+          patched = []
+          for path in pathlib.Path('src').rglob('*.xml'):
+              try:
+                  text = path.read_text(encoding='utf-8')
+              except (UnicodeDecodeError, OSError):
+                  continue
+              new_text, n = attr.subn(rf'\1"{res_norm}"', text)
+              if n:
+                  path.write_text(new_text, encoding='utf-8')
+                  patched.append((str(path), n))
+          if not patched:
+              raise SystemExit(
+                  f"mujoco_ci_camera_resolution={res_norm} was set but no <camera> "
+                  "elements with a resolution attribute were found under src/. "
+                  "Refusing to proceed silently."
+              )
+          print(f"Patched cameras in {len(patched)} file(s) to resolution={res_norm!r}:")
+          for p, n in patched:
+              print(f"  {p} ({n} camera(s))")
           PY
 
       # The 'lo' interfaces will not have multicast, and will fail trying to claim a participant index


### PR DESCRIPTION
## Summary

Mirrors the existing `mujoco_ci_timestep` override: adds a `mujoco_ci_camera_resolution` workflow input that, when set, rewrites every existing `<camera ... resolution="...">` attribute under `src/` to the supplied `"WIDTH HEIGHT"` value before build.

## Motivation

PickNikRobotics/moveit_pro_example_ws#648 standardizes the workspace's MuJoCo `<global offwidth offheight>` to 1280×720 (forced by `picknik_accessories`'s ur5e wrist_camera being 1280×720) and bumps the per-config `<camera>` resolutions to match. The ~3× pixel increase pushed `lab_sim`'s `objectives_integration_test` past its 600s timeout on CI runners (baseline on main: 388s; this PR: >600s timeout, Exit Code `Timeout`).

The product change is intentional — the high-resolution global is required at load time, and 1280×720 cameras are what users will run with. CI just needs a way to render at lower fidelity to stay under timeout. This input is the camera-resolution analog of `mujoco_ci_timestep`.

## Behavior

- Input `mujoco_ci_camera_resolution: "WIDTH HEIGHT"` (string, default `""`). Empty → no-op.
- Validates with `\d+\s+\d+` and rejects non-positive ints.
- Iterates `src/**/*.xml`. For each file, rewrites every `<camera ... resolution="...">` (single- or double-quoted, multi-line tag OK) to the supplied value. Leaves cameras without an existing `resolution=` alone (URDF cameras have non-MuJoCo `<sensor>` syntax).
- Refuses to proceed silently if zero files match (mirrors `mujoco_ci_timestep`).
- Leaves `<global offwidth offheight>` untouched. The load-time constraint is `global >= max(camera)`, so shrinking cameras alone is sufficient and safe.

Dry-run against PickNikRobotics/moveit_pro_example_ws#648's worktree: 21 files / 25 cameras patched, including `picknik_accessories/.../ur5e.xml`'s wrist_camera and the `phoebe_ws` submodule. No false positives.

## Caveat

The blanket override will also rewrite `space_satellite_sim_camera_cal`'s intentional 1920×1080 calibration cameras. There is no integration test for that config today, so this is fine; if one is added later it should opt out by reading the resolution from env in the test.

## Rollout

Consumed by PickNikRobotics/moveit_pro_example_ws#648 (pins to this branch's HEAD SHA pending v0.2.2 release).