### PR TITLE
feat: add enable_gpu input to workspace_integration_test

### DIFF
--- a/.github/workflows/workspace_integration_test.yaml
+++ b/.github/workflows/workspace_integration_test.yaml
@@ -33,6 +33,14 @@ on:
           `CMAKE_{C,CXX}_COMPILER_LAUNCHER` is set to `ccache` for the build step.
         type: boolean
         default: false
+      enable_gpu:
+        description: >
+          If true, pass `--gpus all` to the studio container so workloads inside
+          it can access NVIDIA hardware. The caller is responsible for routing
+          the job to a GPU-equipped runner (e.g. `runner: picknik-16-amd64-gpu`);
+          this flag alone will fail on runners that have no GPU exposed.
+        type: boolean
+        default: false
 
     secrets:
       moveit_license_key:
@@ -54,7 +62,12 @@ jobs:
       MOVEIT_DOCKER_TAG: ${{ inputs.image_tag }}-${{ matrix.ros_distro }}
       # We always need to test in mocked hardware
       MOVEIT_CONFIG_PACKAGE: ${{ inputs.config_package }}
-    container: picknikciuser/moveit-studio:${{ inputs.image_tag }}-${{ matrix.ros_distro }}
+    container:
+      image: picknikciuser/moveit-studio:${{ inputs.image_tag }}-${{ matrix.ros_distro }}
+      # GHA expressions support short-circuit: `cond && 'a' || 'b'`. Empty string
+      # when GPU is disabled is fine — GHA omits empty `options` from the
+      # `docker create` invocation.
+      options: ${{ inputs.enable_gpu && '--gpus all' || '' }}
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
## Problem

The `workspace_integration_test` reusable workflow always runs the studio container without GPU passthrough. Consumers that want to exercise CUDA paths (perception inference, GPU-accelerated simulation) have no way to enable `--gpus all` short of forking the workflow.

## Change

Adds a new boolean input `enable_gpu` (default `false`). When true, the job's container spec expands from the string shorthand to the map form and sets:

```yaml
container:
  image: picknikciuser/moveit-studio:...
  options: ${{ inputs.enable_gpu && '--gpus all' || '' }}
```

GHA's `cond && 'a' || 'b'` short-circuits cleanly here — when `enable_gpu` is false the resulting `options` is the empty string, which GHA omits from the underlying `docker create` invocation, keeping behavior bit-identical to today.

## Alternatives considered

- **Auto-route to a GPU runner when `enable_gpu: true`.** Would prevent the foot-gun of enabling the flag without changing the `runner` input. Rejected because (a) it couples two orthogonal concerns and (b) the caller already chooses the `runner` input explicitly, so silently overriding it would be more surprising than the failure mode (`docker: Error response from daemon: could not select device driver "" with capabilities: [[gpu]]`) when the two settings don't match.
- **Use `inputs.enable_gpu` to set a different `runs-on:`.** Same coupling concern; also `runs-on` doesn't accept ternaries cleanly because it can be a list.

The caller is responsible for pairing `enable_gpu: true` with a GPU-equipped runner, e.g.:

```yaml
jobs:
  integration-test:
    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@main
    with:
      runner: picknik-16-amd64-gpu
      enable_gpu: true
    secrets:
      moveit_license_key: ${{ secrets.MOVEIT_LICENSE_KEY }}
```

The `picknik-16-amd64-gpu` runner tier was added in `moveit_pro_ci_runner_config#3`.