### PR TITLE
docs: document enable_gpu input and drop internal runner name

### DIFF
--- a/.github/workflows/workspace_integration_test.yaml
+++ b/.github/workflows/workspace_integration_test.yaml
@@ -37,8 +37,8 @@ on:
         description: >
           If true, pass `--gpus all` to the studio container so workloads inside
           it can access NVIDIA hardware. The caller is responsible for routing
-          the job to a GPU-equipped runner (e.g. `runner: picknik-16-amd64-gpu`);
-          this flag alone will fail on runners that have no GPU exposed.
+          the job to a GPU-equipped runner; this flag alone will fail on runners
+          that have no GPU exposed.
         type: boolean
         default: false
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ All input args:
 - `runner`: A runner to be passed and run the integration tests. Default: `studio_16_core_runner`.
 - `mujoco_ci_timestep`: If non-empty, set the MuJoCo `<option timestep>` to this value (in seconds) on every top-level `<mujoco>` scene file under `src/` before build. Used to keep the simulator at-or-under realtime on slower CI runners; leave empty for normal runs. Suggested: `"0.004"` (250 Hz). Default: `""`.
 - `use_ccache`: If `true`, use ccache to speed up the colcon build. The ccache directory is restored from and saved to the GitHub Actions cache (keyed by image tag, ROS distro, and config package), and `CMAKE_{C,CXX}_COMPILER_LAUNCHER` is set to `ccache` for the build step. Default: `false`.
+- `enable_gpu`: If `true`, pass `--gpus all` to the studio container so workloads inside it can access NVIDIA hardware (CUDA inference, GPU-accelerated simulation, etc.). The caller is responsible for routing the job to a GPU-equipped runner; setting `enable_gpu: true` on a runner with no GPU exposed will fail at container start with `could not select device driver "" with capabilities: [[gpu]]`. Default: `false`.
 
 Required secrets:
 - `moveit_license_key`: The MoveIt Pro license key. Passing `secrets: inherit` (as in the examples above) is the easiest way to forward it from the calling workflow.


### PR DESCRIPTION
Two doc fixes on top of #24:

- **README missing an entry for `enable_gpu`.** PR #24 added the input but never updated the "All input args" list in the README. Adds the missing line so the input is discoverable from the repo's primary documentation.
- **Internal runner name leaked in the workflow `description:`.** PR #24's `description:` for `enable_gpu` referenced a specific runner name from an internal repo (`moveit_pro_ci_runner_config`). This repo is public and should not name internal infrastructure. Reworded to keep only the generic "GPU-equipped runner" contract — callers still know what they need to pair `enable_gpu: true` with, without exposing what we run internally.

Behavior unchanged; docs only.