### PR TITLE
fix: append CUDA suffix to image when enable_gpu is set

### DIFF
--- a/.github/workflows/workspace_integration_test.yaml
+++ b/.github/workflows/workspace_integration_test.yaml
@@ -63,7 +63,9 @@ jobs:
       # We always need to test in mocked hardware
       MOVEIT_CONFIG_PACKAGE: ${{ inputs.config_package }}
     container:
-      image: picknikciuser/moveit-studio:${{ inputs.image_tag }}-${{ matrix.ros_distro }}
+      # When `enable_gpu` is true, append the CUDA suffix so the runtime image
+      # matches the GPU-enabled MoveIt Pro build.
+      image: picknikciuser/moveit-studio:${{ inputs.image_tag }}-${{ matrix.ros_distro }}${{ inputs.enable_gpu && '-cuda12.6-cudnn9' || '' }}
       # GHA expressions support short-circuit: `cond && 'a' || 'b'`. Empty string
       # when GPU is disabled is fine — GHA omits empty `options` from the
       # `docker create` invocation.


### PR DESCRIPTION
## Problem

PR #24 added an `enable_gpu` input to `workspace_integration_test.yaml` that passes `--gpus all` to the studio container. But the image being pulled was unchanged — still the CPU-only variant — so workloads that needed a CUDA-capable runtime got the wrong image even when `enable_gpu` was true.

## Approach

The GPU-enabled MoveIt Pro images are published with a `-cuda12.6-cudnn9` suffix on the tag. When `enable_gpu` is true, append that suffix to the `container.image` tag, mirroring the short-circuit ternary already used one line below for the `options` field:

```yaml
image: picknikciuser/moveit-studio:${{ inputs.image_tag }}-${{ matrix.ros_distro }}${{ inputs.enable_gpu && '-cuda12.6-cudnn9' || '' }}
options: ${{ inputs.enable_gpu && '--gpus all' || '' }}
```

## Alternatives considered

- **A separate `cuda_suffix` input.** Rejected: callers already opt in via `enable_gpu`, so a second input would be redundant and easy to set inconsistently (GPU on, suffix off — exactly the bug we have today).
- **Hard-code the suffix as a workflow constant.** Same outcome as the inline ternary, but the ternary keeps the value next to the line it affects and matches the `options` line right below.

The suffix `-cuda12.6-cudnn9` is currently the only GPU tag published. If a second CUDA variant ever ships, this should grow into an input — but until then, baking the single supported value in is the simplest correct fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)