### PR TITLE
fix: disambiguate test-results artifact name per ros_distro

### DIFF
--- a/.github/workflows/workspace_integration_test.yaml
+++ b/.github/workflows/workspace_integration_test.yaml
@@ -270,11 +270,15 @@ jobs:
         run: |
           colcon test-result --verbose
 
-      # Upload test results as artifacts to be able to see them in the github actions UI
+      # Upload test results as artifacts to be able to see them in the github actions UI.
+      # Suffix with `matrix.ros_distro` so the humble and jazzy jobs don't both upload
+      # to the same artifact name -- which races on the GitHub Actions side and makes
+      # the per-distro results indistinguishable to downstream consumers
+      # (e.g. a consumer-side `actions/download-artifact` step rendering a report).
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
-          name: test-results-${{ inputs.config_package }}
+          name: test-results-${{ inputs.config_package }}-${{ matrix.ros_distro }}
           path: |
             build/*/test_results/
             build/*/Testing/


### PR DESCRIPTION
## Problem

The reusable workflow's `upload-artifact` step uses the same artifact
name (`test-results-${{ inputs.config_package }}`) for both `humble`
and `jazzy` matrix jobs. Two artifacts with the same name end up in
the run; `actions/download-artifact` by name on the consumer side
picks one nondeterministically, making per-distro results
indistinguishable.

Verified on `PickNikRobotics/moveit_pro_example_ws` run
[26261662688](https://github.com/PickNikRobotics/moveit_pro_example_ws/actions/runs/26261662688):
two artifacts both named `test-results-`, IDs 7150636357 and
7150631494, distinct sizes (~700KB vs ~1.9MB).

## Fix

Suffix the artifact name with `${{ matrix.ros_distro }}` so each
matrix job writes to a unique name. Consumers can now download by
distro deterministically.

## Compatibility

No code currently downloads these artifacts programmatically — they're
only consumed via the GitHub Actions UI today. Renaming is safe.