### PR TITLE
Fix dubious-ownership (exit 128) in the S3 LFS cache path

### DIFF
--- a/.github/workflows/workspace_integration_test.yaml
+++ b/.github/workflows/workspace_integration_test.yaml
@@ -179,6 +179,15 @@ jobs:
         with:
           role-to-assume: ${{ secrets.lfs_cache_role_arn }}
           aws-region: ${{ inputs.lfs_cache_aws_region }}
+      - name: Mark all directories as safe for git
+        if: ${{ inputs.lfs_cache_s3_bucket != '' }}
+        run: |
+          # The cache steps below run raw git in the container (key hashing, the
+          # cache action, git lfs pull across submodules), which trips
+          # "detected dubious ownership" when the checkout is owned by a
+          # different uid than the container user. '*' covers the workspace and
+          # every submodule git dir; safe in an ephemeral single-tenant CI runner.
+          git config --global --add safe.directory '*'
       - name: Compute LFS cache key
         if: ${{ inputs.lfs_cache_s3_bucket != '' }}
         id: lfs_cache_key


### PR DESCRIPTION
## Motivation

`moveit_pro_example_ws` running v0.5.0 failed on the `Compute LFS cache key` step with exit 128 — `fatal: detected dubious ownership in repository at '/__w/.../moveit_pro_example_ws'`. The opt-in LFS cache steps run raw git in the `container:` job (key hashing, `runs-on/cache`'s git, `git lfs pull` incl. submodule `foreach`s); when the checkout is owned by a different uid than the container user, git aborts. The default `lfs: true` path never hits this because it runs no raw git in a separate step.

## Fix

Add `git config --global --add safe.directory '*'` before the cache's git operations, gated on `lfs_cache_s3_bucket != ''` so the default path is untouched. `'*'` covers the workspace **and** every submodule git dir (scoping to `$GITHUB_WORKSPACE` alone would miss the submodule `foreach`s); `--global` persists across the job's steps in the same container.

Follows #29 (added the cache) and the `git_ref`→`ref` typo fix on main.

## Review

This exact step was already reviewed by `code-reviewer` and `platform-architect-bot` (approved, no P0/P1; their P2 comment-wording nits are incorporated here). Functional validation is example_ws #683's re-run after release + ref bump.