### PR TITLE
Add ros_distros input to select integration-test distro matrix

### DIFF
--- a/.github/workflows/workspace_integration_test.yaml
+++ b/.github/workflows/workspace_integration_test.yaml
@@ -82,6 +82,14 @@ on:
         description: AWS region of lfs_cache_s3_bucket.
         type: string
         default: "us-east-1"
+      ros_distros:
+        description: >
+          JSON array of ROS distros to run the integration-test matrix over.
+          The default covers both supported distros; pass a subset (for
+          example, '["jazzy"]') to skip one. Must be a JSON array string so it
+          can feed `fromJSON` in the matrix.
+        type: string
+        default: '["humble", "jazzy"]'
 
     secrets:
       moveit_license_key:
@@ -99,9 +107,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ros_distro:
-          - humble
-          - jazzy
+        # Driven by the `ros_distros` input (default '["humble", "jazzy"]')
+        # so callers can run a subset, e.g. '["jazzy"]' to skip humble.
+        ros_distro: ${{ fromJSON(inputs.ros_distros) }}
     env:
       MOVEIT_LICENSE_KEY: ${{ secrets.moveit_license_key }}
       RMW_IMPLEMENTATION: rmw_cyclonedds_cpp


### PR DESCRIPTION
## Problem

`workspace_integration_test.yaml` hardcodes its `ros_distro` matrix to `[humble, jazzy]`. Callers consuming the reusable workflow cannot run a subset of distros — e.g. to turn off humble integration tests and cut CI cost.

## Change

Add a `ros_distros` input (JSON-array string) that drives the matrix via `fromJSON`:

```yaml
matrix:
  ros_distro: ${{ fromJSON(inputs.ros_distros) }}
```

Default is `'["humble", "jazzy"]'`, so every existing caller is byte-identical — no behavior change unless a caller opts in. Callers select a subset by passing e.g. `ros_distros: '["jazzy"]'`.

## Impact

- Backward-compatible: callers that don't set `ros_distros` still run both distros.
- First consumer: `moveit_pro_example_ws` will pin this release and pass `'["jazzy"]'` to drop humble.

## Follow-up

Cut a release tag after merge so `moveit_pro_example_ws` can pin it.