### PR TITLE
Authenticate container image pull for private image_ref

### DIFF
--- a/.github/workflows/workspace_integration_test.yaml
+++ b/.github/workflows/workspace_integration_test.yaml
@@ -137,7 +137,27 @@ on:
         required: false
 
 jobs:
+  # Fail fast if the registry credentials are half-configured. The container
+  # pull treats an empty username as "anonymous", so a lone password (or a
+  # lone username) would silently fall back to an anonymous pull and 403 deep
+  # in container init with a confusing error. Gate the real job on this so the
+  # misconfiguration surfaces immediately, in plain text.
+  validate-registry-credentials:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require registry credentials to be set as a pair
+        env:
+          REGISTRY_USERNAME: ${{ secrets.image_registry_username }}
+          REGISTRY_PASSWORD: ${{ secrets.image_registry_password }}
+        run: |
+          if { [ -n "$REGISTRY_USERNAME" ] && [ -z "$REGISTRY_PASSWORD" ]; } || \
+             { [ -z "$REGISTRY_USERNAME" ] && [ -n "$REGISTRY_PASSWORD" ]; }; then
+            echo "::error::image_registry_username and image_registry_password must be set together (both or neither)."
+            exit 1
+          fi
+
   integration-test-in-studio-container:
+    needs: validate-registry-credentials
     runs-on: ${{ inputs.runner }}
     strategy:
       fail-fast: false

--- a/.github/workflows/workspace_integration_test.yaml
+++ b/.github/workflows/workspace_integration_test.yaml
@@ -119,6 +119,22 @@ on:
           lfs_cache_s3_bucket. Required when lfs_cache_s3_bucket is set. A secret
           (not an input) so the ARN is not shown in run logs.
         required: false
+      image_registry_username:
+        description: >
+          Username for authenticating the container image pull. Leave unset for
+          public images (the default Docker Hub image needs none); set it with
+          image_registry_password when image_ref points at a private registry
+          — for example a PR-specific GHCR image dispatched from a sister repo,
+          where the consuming repo's own GITHUB_TOKEN has no read access to the
+          producing org's packages. When empty the runner skips docker login
+          and pulls anonymously, preserving the existing public-image behavior.
+        required: false
+      image_registry_password:
+        description: >
+          Password or token paired with image_registry_username. For a private
+          GHCR image, a token (e.g. a GitHub App installation token) with
+          read:packages on the image's org.
+        required: false
 
 jobs:
   integration-test-in-studio-container:
@@ -147,6 +163,13 @@ jobs:
       # this workflow add the CUDA suffix, matching the published tag shape
       # `<tag>-<distro>-<arch><gpu_suffix>`.
       image: ${{ inputs.image_ref != '' && format('{0}{1}', format(inputs.image_ref, matrix.ros_distro), inputs.enable_gpu && inputs.gpu_image_suffix || '') || format('picknikciuser/moveit-studio:{0}-{1}{2}', inputs.image_tag, matrix.ros_distro, inputs.enable_gpu && inputs.gpu_image_suffix || '') }}
+      # Authenticate the image pull when the caller supplies registry
+      # credentials (needed for a private image_ref). The runner skips
+      # docker login when the username is empty, so the default public Docker
+      # Hub image keeps pulling anonymously and existing callers are unchanged.
+      credentials:
+        username: ${{ secrets.image_registry_username }}
+        password: ${{ secrets.image_registry_password }}
       # GHA expressions support short-circuit: `cond && 'a' || 'b'`. Empty string
       # when GPU is disabled is fine — GHA omits empty `options` from the
       # `docker create` invocation.


### PR DESCRIPTION
## Motivation

A consuming repo's integration run (e.g. `moveit_pro_example_ws` PR stacked on a `moveit_pro` PR via the `needs:` token) failed at **Initialize containers** with **403** when `image_ref` pointed at a private image. The `container:` block set `image:` to the (possibly private) `image_ref` but carried **no credentials**, so the runner pulled anonymously — which 403s on a private registry. The `image_ref` docstring already advertised private-image support the workflow couldn't actually authenticate.

## Brief description

Add optional `image_registry_username` / `image_registry_password` secrets and a `container.credentials` block fed by them. When the caller omits them (every current caller, pulling the public Docker Hub default), the username is empty and the runner skips `docker login` — anonymous pull, unchanged behavior. When supplied (private `image_ref`, e.g. a GitHub App token with `read:packages`), the pull authenticates.

## How it was tested

- `python3 -c "yaml.safe_load(...)"` — YAML valid.
- `actionlint 1.7.12` on the workflow — 0 findings.
- Behavior preservation reasoned from the runner's conditional-login: empty username ⇒ no `docker login` ⇒ anonymous pull (existing public-image path).

## Companion change required (other repo)

This unblocks authentication but is not sufficient alone. The caller must (a) pass these two secrets, and (b) point `image_ref` at the registry where the per-PR image actually exists. `moveit_pro_example_ws/.github/workflows/ci.yaml` currently builds a **GHCR** `image_ref` while `moveit_pro` publishes the customer image to **Docker Hub** — that ref must be reconciled (and the matching credentials passed) for the stacked-PR integration run to go green.
